### PR TITLE
Improve error handling.

### DIFF
--- a/src/server/admin.rs
+++ b/src/server/admin.rs
@@ -1,5 +1,6 @@
 //! Admin-only views, generally called by javascript.
-use super::{not_found, permission_denied, redirect_to_img, Context};
+use super::error::ViewResult;
+use super::{redirect_to_img, wrap, Context, Result, ViewError};
 use crate::models::{Coord, Photo, SizeTag};
 use diesel::{self, prelude::*};
 use log::{info, warn};
@@ -8,55 +9,43 @@ use slug::slugify;
 use warp::filters::BoxedFilter;
 use warp::http::response::Builder;
 use warp::reply::Response;
-use warp::{Filter, Rejection, Reply};
+use warp::{Filter, Reply};
 
 pub fn routes(s: BoxedFilter<(Context,)>) -> BoxedFilter<(impl Reply,)> {
     use warp::{body::form, path, post};
     let route = path("grade")
         .and(s.clone())
         .and(form())
-        .and_then(set_grade)
-        .or(path("locate")
-            .and(s.clone())
-            .and(form())
-            .and_then(set_location))
+        .then(set_grade)
+        .or(path("locate").and(s.clone()).and(form()).then(set_location))
         .unify()
-        .or(path("person")
-            .and(s.clone())
-            .and(form())
-            .and_then(set_person))
+        .or(path("person").and(s.clone()).and(form()).then(set_person))
         .unify()
         .or(path("rotate").and(s.clone()).and(form()).map(rotate))
         .unify()
-        .or(path("tag").and(s).and(form()).and_then(set_tag))
-        .unify();
+        .or(path("tag").and(s).and(form()).then(set_tag))
+        .unify()
+        .map(wrap);
     post().and(route).boxed()
 }
 
-fn rotate(context: Context, form: RotateForm) -> Response {
+fn rotate(context: Context, form: RotateForm) -> Result<Response> {
     if !context.is_authorized() {
-        return permission_denied().unwrap();
+        return Err(ViewError::PermissionDenied);
     }
     info!("Should rotate #{} by {}", form.image, form.angle);
     use crate::schema::photos::dsl::photos;
-    let c = context.db().unwrap();
+    let c = context.db()?;
     let c: &PgConnection = &c;
-    if let Ok(mut image) = photos.find(form.image).first::<Photo>(c) {
-        let newvalue = (360 + image.rotation + form.angle) % 360;
-        info!("Rotation was {}, setting to {}", image.rotation, newvalue);
-        image.rotation = newvalue;
-        match image.save_changes::<Photo>(c) {
-            Ok(image) => {
-                context.clear_cache(&image.cache_key(SizeTag::Small));
-                context.clear_cache(&image.cache_key(SizeTag::Medium));
-                return Builder::new().body("ok".into()).unwrap();
-            }
-            Err(error) => {
-                warn!("Failed to save image #{}: {}", image.id, error);
-            }
-        }
-    }
-    not_found(&context)
+    let mut image =
+        or_404q!(photos.find(form.image).first::<Photo>(c), context);
+    let newvalue = (360 + image.rotation + form.angle) % 360;
+    info!("Rotation was {}, setting to {}", image.rotation, newvalue);
+    image.rotation = newvalue;
+    let image = image.save_changes::<Photo>(c)?;
+    context.clear_cache(&image.cache_key(SizeTag::Small));
+    context.clear_cache(&image.cache_key(SizeTag::Medium));
+    Builder::new().body("ok".into()).ise()
 }
 
 #[derive(Deserialize)]
@@ -65,14 +54,12 @@ struct RotateForm {
     angle: i16,
 }
 
-type WarpResult = Result<Response, Rejection>;
-
-async fn set_tag(context: Context, form: TagForm) -> WarpResult {
+async fn set_tag(context: Context, form: TagForm) -> Result<Response> {
     if !context.is_authorized() {
-        return permission_denied();
+        return Err(ViewError::PermissionDenied);
     }
-    let c = context.db().unwrap();
-    use crate::models::{PhotoTag, Tag};
+    let c = context.db()?;
+    use crate::models::Tag;
     let tag = {
         use crate::schema::tags::dsl::*;
         tags.filter(tag_name.ilike(&form.tag))
@@ -84,21 +71,20 @@ async fn set_tag(context: Context, form: TagForm) -> WarpResult {
                         slug.eq(&slugify(&form.tag)),
                     ))
                     .get_result::<Tag>(&c)
-            })
-            .expect("Find or create tag")
+            })?
     };
     use crate::schema::photo_tags::dsl::*;
     let q = photo_tags
         .filter(photo_id.eq(form.image))
-        .filter(tag_id.eq(tag.id));
-    if q.first::<PhotoTag>(&c).is_ok() {
+        .filter(tag_id.eq(tag.id))
+        .count();
+    if q.get_result::<i64>(&c)? > 0 {
         info!("Photo #{} already has {:?}", form.image, form.tag);
     } else {
         info!("Add {:?} on photo #{}!", form.tag, form.image);
         diesel::insert_into(photo_tags)
             .values((photo_id.eq(form.image), tag_id.eq(tag.id)))
-            .execute(&c)
-            .expect("Tag a photo");
+            .execute(&c)?;
     }
     Ok(redirect_to_img(form.image))
 }
@@ -109,26 +95,24 @@ struct TagForm {
     tag: String,
 }
 
-async fn set_person(context: Context, form: PersonForm) -> WarpResult {
+async fn set_person(context: Context, form: PersonForm) -> Result<Response> {
     if !context.is_authorized() {
-        return permission_denied();
+        return Err(ViewError::PermissionDenied);
     }
-    let c = context.db().unwrap();
+    let c = context.db()?;
     use crate::models::{Person, PhotoPerson};
-    let person = Person::get_or_create_name(&c, &form.person)
-        .expect("Find or create person");
+    let person = Person::get_or_create_name(&c, &form.person)?;
     use crate::schema::photo_people::dsl::*;
     let q = photo_people
         .filter(photo_id.eq(form.image))
         .filter(person_id.eq(person.id));
-    if q.first::<PhotoPerson>(&c).is_ok() {
+    if q.first::<PhotoPerson>(&c).optional()?.is_some() {
         info!("Photo #{} already has {:?}", form.image, person);
     } else {
         info!("Add {:?} on photo #{}!", person, form.image);
         diesel::insert_into(photo_people)
             .values((photo_id.eq(form.image), person_id.eq(person.id)))
-            .execute(&c)
-            .expect("Name person in photo");
+            .execute(&c)?;
     }
     Ok(redirect_to_img(form.image))
 }
@@ -139,34 +123,32 @@ struct PersonForm {
     person: String,
 }
 
-async fn set_grade(context: Context, form: GradeForm) -> WarpResult {
+async fn set_grade(context: Context, form: GradeForm) -> Result<Response> {
     if !context.is_authorized() {
-        return permission_denied();
+        return Err(ViewError::PermissionDenied);
     }
     if form.grade >= 0 && form.grade <= 100 {
         info!("Should set grade of #{} to {}", form.image, form.grade);
         use crate::schema::photos::dsl::{grade, photos};
         let q =
             diesel::update(photos.find(form.image)).set(grade.eq(form.grade));
-        match q.execute(&context.db().unwrap()) {
-            Ok(1) => {
+        match q.execute(&context.db()?)? {
+            1 => {
                 return Ok(redirect_to_img(form.image));
             }
-            Ok(0) => (),
-            Ok(n) => {
+            0 => (),
+            n => {
                 warn!("Strange, updated {} images with id {}", n, form.image);
             }
-            Err(error) => {
-                warn!("Failed set grade of image #{}: {}", form.image, error);
-            }
         }
+        Err(ViewError::NotFound(Some(context)))
     } else {
         info!(
             "Grade {} out of range for image #{}",
             form.grade, form.image
         );
+        Err(ViewError::BadRequest("grade out of range"))
     }
-    Ok(not_found(&context))
 }
 
 #[derive(Deserialize)]
@@ -175,9 +157,9 @@ struct GradeForm {
     grade: i16,
 }
 
-async fn set_location(context: Context, form: CoordForm) -> WarpResult {
+async fn set_location(context: Context, form: CoordForm) -> Result<Response> {
     if !context.is_authorized() {
-        return permission_denied();
+        return Err(ViewError::PermissionDenied);
     }
     let image = form.image;
     let coord = form.coord();
@@ -191,8 +173,7 @@ async fn set_location(context: Context, form: CoordForm) -> WarpResult {
         .on_conflict(photo_id)
         .do_update()
         .set((latitude.eq(lat), longitude.eq(lng)))
-        .execute(&context.db().unwrap())
-        .expect("Insert image position");
+        .execute(&context.db()?)?;
     match context
         .overpass()
         .update_image_places(&context.db_pool(), form.image)

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -1,0 +1,152 @@
+use super::Context;
+use crate::photosdir::ImageLoadFailed;
+use crate::templates::{self, RenderError, RenderRucte};
+use log::{error, warn};
+use warp::http::response::Builder;
+use warp::http::status::StatusCode;
+use warp::reply::Response;
+use warp::{self, Rejection, Reply};
+
+pub enum ViewError {
+    /// 404
+    NotFound(Option<Context>),
+    /// 400
+    BadRequest(&'static str),
+    PermissionDenied,
+    /// 503
+    ServiceUnavailable,
+    /// 500
+    Err(&'static str),
+}
+
+macro_rules! or_404 {
+    ($obj:expr, $ctx:expr) => {{
+        match $obj {
+            Some(obj) => obj,
+            None => return Err(ViewError::NotFound(Some($ctx))),
+        }
+    }};
+    ($obj:expr) => {{
+        match $obj {
+            Some(obj) => obj,
+            None => return Err(ViewError::NotFound(None)),
+        }
+    }};
+}
+macro_rules! or_404q {
+    ($obj:expr, $ctx:expr) => {
+        or_404!($obj.optional()?, $ctx)
+    };
+}
+
+pub trait ViewResult<T> {
+    fn ise(self) -> Result<T, ViewError>;
+    fn req(self, msg: &'static str) -> Result<T, ViewError>;
+}
+
+impl<T, E> ViewResult<T> for Result<T, E>
+where
+    E: std::fmt::Debug,
+{
+    fn ise(self) -> Result<T, ViewError> {
+        self.map_err(|e| {
+            error!("Internal server error: {:?}", e);
+            ViewError::Err("Something went wrong")
+        })
+    }
+    fn req(self, msg: &'static str) -> Result<T, ViewError> {
+        self.map_err(|e| {
+            warn!("Bad request, {}: {:?}", msg, e);
+            ViewError::BadRequest(msg)
+        })
+    }
+}
+
+impl Reply for ViewError {
+    fn into_response(self) -> Response {
+        match self {
+            ViewError::NotFound(Some(context)) => Builder::new()
+                .status(StatusCode::NOT_FOUND)
+                .html(|o| {
+                    templates::not_found(
+                        o,
+                        &context,
+                        StatusCode::NOT_FOUND,
+                        "The resource you requested could not be located",
+                    )
+                })
+                .unwrap_or_else(|_| StatusCode::NOT_FOUND.into_response()),
+            ViewError::NotFound(None) => error_response(
+                StatusCode::NOT_FOUND,
+                "Not found",
+                "The resource you requested could not be located.",
+            ),
+            ViewError::BadRequest(msg) => {
+                error_response(StatusCode::BAD_REQUEST, msg, "Sorry.")
+            }
+            ViewError::PermissionDenied => {
+                error_response(StatusCode::UNAUTHORIZED, "Sorry", "Sorry.")
+            }
+            ViewError::ServiceUnavailable => error_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Server exhausted",
+                "The server is exhausted and can't handle your request \
+                 right now. Sorry. \
+                 Please try again later.",
+            ),
+            ViewError::Err(msg) => error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                msg,
+                "This is an error in the server code or configuration. \
+                 Sorry. \
+                 The error has been logged and I will try to fix it.",
+            ),
+        }
+    }
+}
+
+fn error_response(code: StatusCode, message: &str, detail: &str) -> Response {
+    Builder::new()
+        .status(code)
+        .html(|o| templates::error(o, code, message, detail))
+        .unwrap_or_else(|_| code.into_response())
+}
+
+impl From<RenderError> for ViewError {
+    fn from(e: RenderError) -> Self {
+        error!("Rendering error: {}\n    {:?}", e, e);
+        ViewError::Err("Rendering error")
+    }
+}
+
+impl From<diesel::result::Error> for ViewError {
+    fn from(e: diesel::result::Error) -> Self {
+        error!("Database error: {}\n    {:?}", e, e);
+        ViewError::Err("Database error")
+    }
+}
+
+impl From<r2d2_memcache::memcache::Error> for ViewError {
+    fn from(e: r2d2_memcache::memcache::Error) -> Self {
+        error!("Pool error: {:?}", e);
+        ViewError::Err("Pool error")
+    }
+}
+impl From<ImageLoadFailed> for ViewError {
+    fn from(e: ImageLoadFailed) -> Self {
+        error!("Image load error: {:?}", e);
+        ViewError::Err("Failed to load image")
+    }
+}
+
+/// Create custom errors for warp rejections.
+///
+/// Currently only handles 404, as there is no way of getting any
+/// details out of the other build-in rejections in warp.
+pub async fn for_rejection(err: Rejection) -> Result<Response, Rejection> {
+    if err.is_not_found() {
+        Ok(ViewError::NotFound(None).into_response())
+    } else {
+        Err(err)
+    }
+}

--- a/src/server/image.rs
+++ b/src/server/image.rs
@@ -1,5 +1,5 @@
 use super::BuilderExt;
-use super::{error_response, not_found, Context};
+use super::{error::ViewResult, Context, Result, ViewError};
 use crate::models::{Photo, SizeTag};
 use crate::photosdir::{get_scaled_jpeg, ImageLoadFailed};
 use diesel::prelude::*;
@@ -7,57 +7,38 @@ use std::str::FromStr;
 use warp::http::response::Builder;
 use warp::http::{header, StatusCode};
 use warp::reply::Response;
-use warp::Rejection;
 
-pub async fn show_image(
-    img: ImgName,
-    context: Context,
-) -> Result<Response, Rejection> {
+pub async fn show_image(img: ImgName, context: Context) -> Result<Response> {
     use crate::schema::photos::dsl::photos;
-    let tphoto = photos.find(img.id).first::<Photo>(&context.db().unwrap());
+    let tphoto = photos.find(img.id).first::<Photo>(&context.db()?);
     if let Ok(tphoto) = tphoto {
         if context.is_authorized() || tphoto.is_public() {
             if img.size == SizeTag::Large {
                 if context.is_authorized() {
-                    use std::fs::File;
-                    use std::io::Read;
-                    // TODO: This should be done in a more async-friendly way.
                     let path = context.photos().get_raw_path(&tphoto);
-                    let mut buf = Vec::new();
-                    if File::open(path)
-                        .map(|mut f| f.read_to_end(&mut buf))
-                        .is_ok()
-                    {
-                        return Ok(Builder::new()
-                            .status(StatusCode::OK)
-                            .header(
-                                header::CONTENT_TYPE,
-                                mime::IMAGE_JPEG.as_ref(),
-                            )
-                            .far_expires()
-                            .body(buf.into())
-                            .unwrap());
-                    } else {
-                        return Ok(error_response(
-                            StatusCode::INTERNAL_SERVER_ERROR,
+                    let buf = tokio::fs::read(path).await.ise()?;
+                    return Builder::new()
+                        .status(StatusCode::OK)
+                        .header(
+                            header::CONTENT_TYPE,
+                            mime::IMAGE_JPEG.as_ref(),
                         )
-                        .unwrap());
-                    }
+                        .far_expires()
+                        .body(buf.into())
+                        .ise();
                 }
             } else {
-                let data = get_image_data(&context, &tphoto, img.size)
-                    .await
-                    .expect("Get image data");
-                return Ok(Builder::new()
+                let data = get_image_data(&context, &tphoto, img.size).await?;
+                return Builder::new()
                     .status(StatusCode::OK)
                     .header(header::CONTENT_TYPE, mime::IMAGE_JPEG.as_ref())
                     .far_expires()
                     .body(data.into())
-                    .unwrap());
+                    .ise();
             }
         }
     }
-    Ok(not_found(&context))
+    Err(ViewError::NotFound(Some(context)))
 }
 
 /// A client-side / url file name for a file.

--- a/src/server/views_by_date.rs
+++ b/src/server/views_by_date.rs
@@ -1,5 +1,7 @@
 use super::splitlist::links_by_time;
-use super::{not_found, redirect_to_img, Context, ImgRange, Link, PhotoLink};
+use super::{
+    redirect_to_img, Context, ImgRange, Link, PhotoLink, Result, ViewError,
+};
 use crate::models::{Photo, SizeTag};
 use crate::templates::{self, RenderRucte};
 use chrono::naive::{NaiveDate, NaiveDateTime};
@@ -7,22 +9,20 @@ use chrono::{Datelike, Duration, Local};
 use diesel::dsl::sql;
 use diesel::prelude::*;
 use diesel::sql_types::{BigInt, Integer, Nullable};
-use log::warn;
 use serde::Deserialize;
 use warp::http::response::Builder;
 use warp::reply::Response;
 
-pub fn all_years(context: Context) -> Response {
+pub fn all_years(context: Context) -> Result<Response> {
     use crate::schema::photos::dsl::{date, grade};
-    let db = context.db().unwrap();
+    let db = context.db()?;
     let groups = Photo::query(context.is_authorized())
         .select(sql::<(Nullable<Integer>, BigInt)>(
             "cast(extract(year from date) as int) y, count(*)",
         ))
         .group_by(sql::<Nullable<Integer>>("y"))
         .order(sql::<Nullable<Integer>>("y").desc().nulls_last())
-        .load::<(Option<i32>, i64)>(&db)
-        .unwrap()
+        .load::<(Option<i32>, i64)>(&db)?
         .iter()
         .map(|&(year, count)| {
             let q = Photo::query(context.is_authorized())
@@ -34,8 +34,8 @@ pub fn all_years(context: Context) -> Response {
             } else {
                 q.filter(date.is_null())
             };
-            let photo = photo.first::<Photo>(&db).unwrap();
-            PhotoLink {
+            let photo = photo.first::<Photo>(&db)?;
+            Ok(PhotoLink {
                 title: Some(
                     year.map(|y| format!("{}", y))
                         .unwrap_or_else(|| "-".to_string()),
@@ -44,26 +44,24 @@ pub fn all_years(context: Context) -> Response {
                 lable: Some(format!("{} images", count)),
                 id: photo.id,
                 size: photo.get_size(SizeTag::Small),
-            }
+            })
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>>>()?;
 
-    Builder::new()
-        .html(|o| {
-            templates::index(o, &context, "All photos", &[], &groups, &[])
-        })
-        .unwrap()
+    Ok(Builder::new().html(|o| {
+        templates::index(o, &context, "All photos", &[], &groups, &[])
+    })?)
 }
 
 fn start_of_year(year: i32) -> NaiveDateTime {
     NaiveDate::from_ymd(year, 1, 1).and_hms(0, 0, 0)
 }
 
-pub fn months_in_year(year: i32, context: Context) -> Response {
+pub fn months_in_year(year: i32, context: Context) -> Result<Response> {
     use crate::schema::photos::dsl::{date, grade};
 
     let title: String = format!("Photos from {}", year);
-    let db = context.db().unwrap();
+    let db = context.db()?;
     let groups = Photo::query(context.is_authorized())
         .filter(date.ge(start_of_year(year)))
         .filter(date.lt(start_of_year(year + 1)))
@@ -72,8 +70,7 @@ pub fn months_in_year(year: i32, context: Context) -> Response {
         ))
         .group_by(sql::<Integer>("m"))
         .order(sql::<Integer>("m").desc().nulls_last())
-        .load::<(i32, i64)>(&db)
-        .unwrap()
+        .load::<(i32, i64)>(&db)?
         .iter()
         .map(|&(month, count)| {
             let month = month as u32;
@@ -82,21 +79,20 @@ pub fn months_in_year(year: i32, context: Context) -> Response {
                 .filter(date.lt(start_of_month(year, month + 1)))
                 .order((grade.desc().nulls_last(), date.asc()))
                 .limit(1)
-                .first::<Photo>(&db)
-                .unwrap();
+                .first::<Photo>(&db)?;
 
-            PhotoLink {
+            Ok(PhotoLink {
                 title: Some(monthname(month).to_string()),
                 href: format!("/{}/{}/", year, month),
                 lable: Some(format!("{} pictures", count)),
                 id: photo.id,
                 size: photo.get_size(SizeTag::Small),
-            }
+            })
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>>>()?;
 
     if groups.is_empty() {
-        not_found(&context)
+        Err(ViewError::NotFound(Some(context)))
     } else {
         use crate::schema::positions::dsl::{
             latitude, longitude, photo_id, positions,
@@ -106,19 +102,15 @@ pub fn months_in_year(year: i32, context: Context) -> Response {
             .filter(date.ge(start_of_year(year)))
             .filter(date.lt(start_of_year(year + 1)))
             .select((photo_id, latitude, longitude))
-            .load(&db)
-            .map_err(|e| warn!("Failed to load positions: {}", e))
-            .unwrap_or_default()
+            .load(&db)?
             .into_iter()
             .map(|(p_id, lat, long): (i32, i32, i32)| {
                 ((lat, long).into(), p_id)
             })
             .collect::<Vec<_>>();
-        Builder::new()
-            .html(|o| {
-                templates::index(o, &context, &title, &[], &groups, &pos)
-            })
-            .unwrap()
+        Ok(Builder::new().html(|o| {
+            templates::index(o, &context, &title, &[], &groups, &pos)
+        })?)
     }
 }
 
@@ -131,12 +123,16 @@ fn start_of_month(year: i32, month: u32) -> NaiveDateTime {
     date.and_hms(0, 0, 0)
 }
 
-pub fn days_in_month(year: i32, month: u32, context: Context) -> Response {
+pub fn days_in_month(
+    year: i32,
+    month: u32,
+    context: Context,
+) -> Result<Response> {
     use crate::schema::photos::dsl::{date, grade};
 
     let lpath: Vec<Link> = vec![Link::year(year)];
     let title: String = format!("Photos from {} {}", monthname(month), year);
-    let db = context.db().unwrap();
+    let db = context.db()?;
     let groups = Photo::query(context.is_authorized())
         .filter(date.ge(start_of_month(year, month)))
         .filter(date.lt(start_of_month(year, month + 1)))
@@ -145,8 +141,7 @@ pub fn days_in_month(year: i32, month: u32, context: Context) -> Response {
         ))
         .group_by(sql::<Integer>("d"))
         .order(sql::<Integer>("d").desc().nulls_last())
-        .load::<(i32, i64)>(&db)
-        .unwrap()
+        .load::<(i32, i64)>(&db)?
         .iter()
         .map(|&(day, count)| {
             let day = day as u32;
@@ -157,21 +152,20 @@ pub fn days_in_month(year: i32, month: u32, context: Context) -> Response {
                 .filter(date.lt(fromdate + Duration::days(1)))
                 .order((grade.desc().nulls_last(), date.asc()))
                 .limit(1)
-                .first::<Photo>(&db)
-                .unwrap();
+                .first::<Photo>(&db)?;
 
-            PhotoLink {
+            Ok(PhotoLink {
                 title: Some(format!("{}", day)),
                 href: format!("/{}/{}/{}", year, month, day),
                 lable: Some(format!("{} pictures", count)),
                 id: photo.id,
                 size: photo.get_size(SizeTag::Small),
-            }
+            })
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>>>()?;
 
     if groups.is_empty() {
-        not_found(&context)
+        Err(ViewError::NotFound(Some(context)))
     } else {
         use crate::schema::positions::dsl::{
             latitude, longitude, photo_id, positions,
@@ -181,45 +175,38 @@ pub fn days_in_month(year: i32, month: u32, context: Context) -> Response {
             .filter(date.ge(start_of_month(year, month)))
             .filter(date.lt(start_of_month(year, month + 1)))
             .select((photo_id, latitude, longitude))
-            .load(&db)
-            .map_err(|e| warn!("Failed to load positions: {}", e))
-            .unwrap_or_default()
+            .load(&db)?
             .into_iter()
             .map(|(p_id, lat, long): (i32, i32, i32)| {
                 ((lat, long).into(), p_id)
             })
             .collect::<Vec<_>>();
-        Builder::new()
-            .html(|o| {
-                templates::index(o, &context, &title, &lpath, &groups, &pos)
-            })
-            .unwrap()
+        Ok(Builder::new().html(|o| {
+            templates::index(o, &context, &title, &lpath, &groups, &pos)
+        })?)
     }
 }
 
-pub fn all_null_date(context: Context) -> Response {
+pub fn all_null_date(context: Context) -> Result<Response> {
     use crate::schema::photos::dsl::{date, path};
-
-    Builder::new()
-        .html(|o| {
-            templates::index(
-                o,
-                &context,
-                "Photos without a date",
-                &[],
-                &Photo::query(context.is_authorized())
-                    .filter(date.is_null())
-                    .order(path.asc())
-                    .limit(500)
-                    .load(&context.db().unwrap())
-                    .unwrap()
-                    .iter()
-                    .map(PhotoLink::no_title)
-                    .collect::<Vec<_>>(),
-                &[], // Don't care about positions here
-            )
-        })
-        .unwrap()
+    let images = Photo::query(context.is_authorized())
+        .filter(date.is_null())
+        .order(path.asc())
+        .limit(500)
+        .load(&context.db()?)?
+        .iter()
+        .map(PhotoLink::no_title)
+        .collect::<Vec<_>>();
+    Ok(Builder::new().html(|o| {
+        templates::index(
+            o,
+            &context,
+            "Photos without a date",
+            &[],
+            &images,
+            &[], // Don't care about positions here
+        )
+    })?)
 }
 
 pub fn all_for_day(
@@ -228,39 +215,32 @@ pub fn all_for_day(
     day: u32,
     range: ImgRange,
     context: Context,
-) -> Response {
+) -> Result<Response> {
     let thedate = NaiveDate::from_ymd(year, month, day).and_hms(0, 0, 0);
     use crate::schema::photos::dsl::date;
 
     let photos = Photo::query(context.is_authorized())
         .filter(date.ge(thedate))
         .filter(date.lt(thedate + Duration::days(1)));
-    let (links, coords) = links_by_time(&context, photos, range, false);
+    let (links, coords) = links_by_time(&context, photos, range, false)?;
 
     if links.is_empty() {
-        not_found(&context)
+        Err(ViewError::NotFound(Some(context)))
     } else {
-        Builder::new()
-            .html(|o| {
-                templates::index(
-                    o,
-                    &context,
-                    &format!(
-                        "Photos from {} {} {}",
-                        day,
-                        monthname(month),
-                        year
-                    ),
-                    &[Link::year(year), Link::month(year, month)],
-                    &links,
-                    &coords,
-                )
-            })
-            .unwrap()
+        Ok(Builder::new().html(|o| {
+            templates::index(
+                o,
+                &context,
+                &format!("Photos from {} {} {}", day, monthname(month), year),
+                &[Link::year(year), Link::month(year, month)],
+                &links,
+                &coords,
+            )
+        })?)
     }
 }
 
-pub fn on_this_day(context: Context) -> Response {
+pub fn on_this_day(context: Context) -> Result<Response> {
     use crate::schema::photos::dsl::{date, grade};
     use crate::schema::positions::dsl::{
         latitude, longitude, photo_id, positions,
@@ -270,7 +250,7 @@ pub fn on_this_day(context: Context) -> Response {
         let today = Local::now();
         (today.month(), today.day())
     };
-    let db = context.db().unwrap();
+    let db = context.db()?;
     let pos = Photo::query(context.is_authorized())
         .inner_join(positions)
         .filter(
@@ -278,98 +258,87 @@ pub fn on_this_day(context: Context) -> Response {
         )
         .filter(sql("extract(day from date)=").bind::<Integer, _>(day as i32))
         .select((photo_id, latitude, longitude))
-        .load(&db)
-        .map_err(|e| warn!("Failed to load positions: {}", e))
-        .unwrap_or_default()
+        .load(&db)?
         .into_iter()
         .map(|(p_id, lat, long): (i32, i32, i32)| ((lat, long).into(), p_id))
         .collect::<Vec<_>>();
 
-    Builder::new()
-        .html(|o| {
-            templates::index(
-                o,
-                &context,
-                &format!("Photos from {} {}", day, monthname(month)),
-                &[],
-                &Photo::query(context.is_authorized())
-                    .select(sql::<(Integer, BigInt)>(
-                        "cast(extract(year from date) as int) y, count(*)",
-                    ))
-                    .group_by(sql::<Integer>("y"))
-                    .filter(
-                        sql("extract(month from date)=")
-                            .bind::<Integer, _>(month as i32),
-                    )
-                    .filter(
-                        sql("extract(day from date)=")
-                            .bind::<Integer, _>(day as i32),
-                    )
-                    .order(sql::<Integer>("y").desc())
-                    .load::<(i32, i64)>(&db)
-                    .unwrap()
-                    .iter()
-                    .map(|&(year, count)| {
-                        let fromdate =
-                            NaiveDate::from_ymd(year, month as u32, day)
-                                .and_hms(0, 0, 0);
-                        let photo = Photo::query(context.is_authorized())
-                            .filter(date.ge(fromdate))
-                            .filter(date.lt(fromdate + Duration::days(1)))
-                            .order((grade.desc().nulls_last(), date.asc()))
-                            .limit(1)
-                            .first::<Photo>(&db)
-                            .unwrap();
-
-                        PhotoLink {
-                            title: Some(format!("{}", year)),
-                            href: format!("/{}/{}/{}", year, month, day),
-                            lable: Some(format!("{} pictures", count)),
-                            id: photo.id,
-                            size: photo.get_size(SizeTag::Small),
-                        }
-                    })
-                    .collect::<Vec<_>>(),
-                &pos,
-            )
+    let photos = Photo::query(context.is_authorized())
+        .select(sql::<(Integer, BigInt)>(
+            "cast(extract(year from date) as int) y, count(*)",
+        ))
+        .group_by(sql::<Integer>("y"))
+        .filter(
+            sql("extract(month from date)=").bind::<Integer, _>(month as i32),
+        )
+        .filter(sql("extract(day from date)=").bind::<Integer, _>(day as i32))
+        .order(sql::<Integer>("y").desc())
+        .load::<(i32, i64)>(&db)?
+        .iter()
+        .map(|&(year, count)| {
+            let fromdate =
+                NaiveDate::from_ymd(year, month as u32, day).and_hms(0, 0, 0);
+            let photo = Photo::query(context.is_authorized())
+                .filter(date.ge(fromdate))
+                .filter(date.lt(fromdate + Duration::days(1)))
+                .order((grade.desc().nulls_last(), date.asc()))
+                .limit(1)
+                .first::<Photo>(&db)?;
+            Ok(PhotoLink {
+                title: Some(format!("{}", year)),
+                href: format!("/{}/{}/{}", year, month, day),
+                lable: Some(format!("{} pictures", count)),
+                id: photo.id,
+                size: photo.get_size(SizeTag::Small),
+            })
         })
-        .unwrap()
+        .collect::<Result<Vec<_>>>()?;
+    Ok(Builder::new().html(|o| {
+        templates::index(
+            o,
+            &context,
+            &format!("Photos from {} {}", day, monthname(month)),
+            &[],
+            &photos,
+            &pos,
+        )
+    })?)
 }
 
-pub fn next_image(context: Context, param: FromParam) -> Response {
+pub fn next_image(context: Context, param: FromParam) -> Result<Response> {
     use crate::schema::photos::dsl::{date, id};
-    let db = context.db().unwrap();
-    if let Some(from_date) = date_of_img(&db, param.from) {
-        let q = Photo::query(context.is_authorized())
+    let db = context.db()?;
+    let from_date = or_404!(date_of_img(&db, param.from), context);
+    let photo = or_404q!(
+        Photo::query(context.is_authorized())
             .select(id)
             .filter(
                 date.gt(from_date)
                     .or(date.eq(from_date).and(id.gt(param.from))),
             )
-            .order((date, id));
-        if let Ok(photo) = q.first::<i32>(&db) {
-            return redirect_to_img(photo);
-        }
-    }
-    not_found(&context)
+            .order((date, id))
+            .first::<i32>(&db),
+        context
+    );
+    Ok(redirect_to_img(photo))
 }
 
-pub fn prev_image(context: Context, param: FromParam) -> Response {
+pub fn prev_image(context: Context, param: FromParam) -> Result<Response> {
     use crate::schema::photos::dsl::{date, id};
-    let db = context.db().unwrap();
-    if let Some(from_date) = date_of_img(&db, param.from) {
-        let q = Photo::query(context.is_authorized())
+    let db = context.db()?;
+    let from_date = or_404!(date_of_img(&db, param.from), context);
+    let photo = or_404q!(
+        Photo::query(context.is_authorized())
             .select(id)
             .filter(
                 date.lt(from_date)
                     .or(date.eq(from_date).and(id.lt(param.from))),
             )
-            .order((date.desc().nulls_last(), id.desc()));
-        if let Ok(photo) = q.first::<i32>(&db) {
-            return redirect_to_img(photo);
-        }
-    }
-    not_found(&context)
+            .order((date.desc().nulls_last(), id.desc()))
+            .first::<i32>(&db),
+        context
+    );
+    Ok(redirect_to_img(photo))
 }
 
 #[derive(Deserialize)]

--- a/templates/error.rs.html
+++ b/templates/error.rs.html
@@ -1,7 +1,7 @@
 @use super::statics::{photos_css, ux_js};
 @use warp::http::StatusCode;
 
-@(code: StatusCode, message: &str)
+@(code: StatusCode, message: &str, detail: &str)
 
 <!doctype html>
 <html>
@@ -27,6 +27,7 @@
     <main>
       <h1>@code.canonical_reason().unwrap_or("error")</h1>
       <p>@message (@code.as_u16())</p>
+      <p>@detail</p>
     </main>
     <footer>
       <p>Managed by


### PR DESCRIPTION
Views now returns `Result<T: Reply, ViewError>`. There is a difference between a `ViewError` (an error that can be represented as a http response) and a `Rejection` (which tells the warp filter system to try other possible handlers).

Get rid of lots of "unwrap" (potential panics) in view handlers.
